### PR TITLE
Remove javascript warning

### DIFF
--- a/lib/src/gadget/extensions.cljc
+++ b/lib/src/gadget/extensions.cljc
@@ -12,7 +12,7 @@
    [:gadget/string (pr-str (str (first (str/split raw #"\.")) "..."))]])
 
 (defn- base64json [s]
-  #?(:cljs (-> s js/atob JSON.parse (js->clj :keywordize-keys true))))
+  #?(:cljs (-> s js/atob js/JSON.parse (js->clj :keywordize-keys true))))
 
 (defrecord JWT [header data sig]
   gadget/Browsable


### PR DESCRIPTION
In shadow-cljs this is very apparent:

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: gadget/extensions.cljc:15:26
--------------------------------------------------------------------------------
  12 |    [:gadget/string (pr-str (str (first (str/split raw #"\.")) "..."))]])
  13 |
  14 | (defn- base64json [s]
  15 |   #?(:cljs (-> s js/atob JSON.parse (js->clj :keywordize-keys true))))
--------------------------------^-----------------------------------------------
 Use of undeclared Var gadget.extensions/JSON
--------------------------------------------------------------------------------
```

Works fine, of course.