### PR TITLE
Fix JavaScript warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ As an example, let's consider how Gadget recognizes and navigates JWTs:
       :jwt)))
 
 (defn- base64json [s]
-  (-> s js/atob JSON.parse (js->clj :keywordize-keys true)))
+  (-> s js/atob js/JSON.parse (js->clj :keywordize-keys true)))
 
 (defmethod datafy/datafy :jwt [token]
   (let [[header data sig] (str/split token #"\.")]

--- a/lib/src/gadget/extensions.cljc
+++ b/lib/src/gadget/extensions.cljc
@@ -13,7 +13,7 @@
    [:gadget/string (pr-str (str (first (str/split raw #"\.")) "..."))]])
 
 (defn- base64json [s]
-  #?(:cljs (-> s js/atob JSON.parse (js->clj :keywordize-keys true))))
+  #?(:cljs (-> s js/atob js/JSON.parse (js->clj :keywordize-keys true))))
 
 (defrecord JWT [header data sig]
   browsable/Browsable


### PR DESCRIPTION
When using this library in a shadow-cljs based project, you get the following JavaScript warning:

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: gadget/extensions.cljc:16:26
--------------------------------------------------------------------------------
  13 |    [:gadget/string (pr-str (str (first (str/split raw #"\.")) "..."))]])
  14 |
  15 | (defn- base64json [s]
  16 |   #?(:cljs (-> s js/atob JSON.parse (js->clj :keywordize-keys true))))
--------------------------------^-----------------------------------------------
 Use of undeclared Var gadget.extensions/JSON
--------------------------------------------------------------------------------
  17 |
  18 | (defrecord JWT [header data sig]
  19 |   browsable/Browsable
  20 |   (entries [jwt]
--------------------------------------------------------------------------------
```

This PR fixes that warning by replacing `JSON.parse` with `js/JSON.parse`.